### PR TITLE
Add SVModular DrumKit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,7 @@
 [submodule "Sapphire/sapphire"]
 	path = Sapphire/sapphire
 	url = https://github.com/4ms/sapphire.git
+[submodule "DrumKit"]
+	path = DrumKit
+	url = https://github.com/4ms/DrumKit
+	branch = metamodule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PLUGINS
     NANO
     VCV-Fundamental
     Sapphire
+    DrumKit
 )
 
 foreach(plugin ${PLUGINS})
@@ -31,6 +32,7 @@ foreach(plugin ${PLUGINS})
     ExternalProject_Add(
         ${plugin}
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/${plugin}
+        CMAKE_ARGS -DMETAMODULE_SDK_DIR=${CMAKE_CURRENT_LIST_DIR}/metamodule-plugin-sdk -DINSTALL_DIR=${CMAKE_CURRENT_LIST_DIR}/metamodule-plugins
         BUILD_ALWAYS true
         INSTALL_COMMAND ""
     )


### PR DESCRIPTION
Adds all DrumKit modules from SVModular.

To note, this plugin is build in-situ rather than having a wrapper repo around like most of the other Rack-based plugins.
A CMakeLists.txt file was added to the fork which handles the building. A helper makefile was also added for building outside of the plugins-examples repo (`make mm-plugin`)